### PR TITLE
Fix the order of the licenses passed

### DIFF
--- a/licomp_toolkit/__main__.py
+++ b/licomp_toolkit/__main__.py
@@ -28,8 +28,8 @@ class LicompToolkitParser(LicompParser):
         return self.flame.expression_license(lic_name, update_dual=False)['identified_license']
 
     def verify(self, args):
-        compatibilities = self.licomp_toolkit.outbound_inbound_compatibility(self.__normalize_license(args.in_license),
-                                                                             self.__normalize_license(args.out_license),
+        compatibilities = self.licomp_toolkit.outbound_inbound_compatibility(self.__normalize_license(args.out_license),
+                                                                             self.__normalize_license(args.in_license),
                                                                              args.usecase,
                                                                              args.provisioning)
         formatter = LicompToolkitFormatter.formatter(self.args.output_format)

--- a/tests/shell/test-cli.sh
+++ b/tests/shell/test-cli.sh
@@ -75,12 +75,12 @@ test_licomp_tk "-u snippet verify -il MIT -ol MIT" ".summary.results.nr_valid" 2
 test_licomp_tk "-u snippet verify -il MIT -ol MIT2" ".summary.results.nr_valid" 0
 test_licomp_tk "-u snippet verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.nr_valid" 2
 test_licomp_tk "-u snippet verify -il LGPL-2.1-or-later -ol BSD-3-Clause" ".summary.results.nr_valid" 2
-test_licomp_tk "-u snippet verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.yes.count" null
-test_licomp_tk "-u snippet verify -il LGPL-2.1-or-later -ol BSD-3-Clause" ".summary.results.yes.count" 2
+test_licomp_tk "-u snippet verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.yes.count" 2
+test_licomp_tk "-u snippet verify -il LGPL-2.1-or-later -ol BSD-3-Clause" ".summary.results.yes.count" null
 
 echo "# snippet vs bin dist"
 test_licomp_tk "-u snippet verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.nr_valid" 2
-test_licomp_tk "-u snippet verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.no.count" 2
+test_licomp_tk "-u snippet verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.yes.count" 2
 test_licomp_tk "verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.nr_valid" 2
 test_licomp_tk "verify -il BSD-3-Clause -ol LGPL-2.1-or-later" ".summary.results.yes.count" 2
 


### PR DESCRIPTION
When user supplied inbound and outbound license to the `verify` command, the call to `outbound_inbound_compatibility` passed the licenses in the wrong order.

With this commit, the order is correct