### PR TITLE
Only add compatible licenses if successful call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# internal test files
+*.tmp
+
 # C extensions
 *.so
 
@@ -160,3 +163,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+

--- a/licomp_toolkit/suggester.py
+++ b/licomp_toolkit/suggester.py
@@ -134,12 +134,12 @@ class OutboundSuggester:
                                                   usecase,
                                                   provisioning,
                                                   resources)
+                if ret['compatibility'] == 'yes':
+                    compats.append(lic)
+                    logging.debug(f' appending: {lic}')
             except Exception as e:
                 logging.debug(f'Exception caught: {e}')
                 logging.debug(traceback.format_exc())
-            if ret['compatibility'] == 'yes':
-                compats.append(lic)
-                logging.debug(f' appending: {lic}')
 
         # decorate compat list with indices (from rankings)
         decorated = [(self.__compat_index(lic, usecase, provisioning), lic) for lic in compats]

--- a/licomp_toolkit_test.tmp
+++ b/licomp_toolkit_test.tmp
@@ -1,5 +1,0 @@
-digraph depends {
-    graph [label="License Compatibility Graph (library)" labelloc=t]
-    node [shape=plaintext]
-    "MIT" -> "BSD-3-Clause" [dir="both" color="darkgreen" ]
-}


### PR DESCRIPTION
When calling `outbound-candidate` with faulty parameters:
```
$ ./devel/licomp-toolkit --usecase weird-unknown-usecase outbound-candidate "APA OR MIT"
```
then `licomp-toolkit` crashes with `UnboundLocalError: cannot access local variable 'ret' where it is not associated with a value`

With this fix the returned data is only read and used on successful response.